### PR TITLE
add epoch counter to sklearn discharge model metrics

### DIFF
--- a/discharge_model/DischargeModel.ipynb
+++ b/discharge_model/DischargeModel.ipynb
@@ -596,7 +596,10 @@
     "            \"R2_test\": [self.model.score(\n",
     "                self.scaled_feats[\"feat_test_scaled\"],\n",
     "                self.dataset[\"label_test\"]\n",
-    "            )]\n",
+    "            )],\n",
+    "            \"epochs\": [\n",
+    "                self.model.n_iter_\n",
+    "            ]\n",
     "        }, index=[self.name])\n",
     "\n",
     "    def plot_accuracy(self):\n",
@@ -690,6 +693,10 @@
        "      <th>R2_test</th>\n",
        "      <td>0.788128</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>epochs</th>\n",
+       "      <td>84.000000</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -699,10 +706,11 @@
        "RMSE_train                    70.172594\n",
        "RMSE_test                    101.595032\n",
        "R2_train                       0.921435\n",
-       "R2_test                        0.788128"
+       "R2_test                        0.788128\n",
+       "epochs                        84.000000"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -816,6 +824,7 @@
        "      <th>RMSE_test</th>\n",
        "      <th>R2_train</th>\n",
        "      <th>R2_test</th>\n",
+       "      <th>epochs</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -825,6 +834,7 @@
        "      <td>266.750283</td>\n",
        "      <td>0.988114</td>\n",
        "      <td>0.286956</td>\n",
+       "      <td>171</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>base model (fast charge)</th>\n",
@@ -832,18 +842,19 @@
        "      <td>85.076788</td>\n",
        "      <td>0.920004</td>\n",
        "      <td>0.740799</td>\n",
+       "      <td>38</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                          RMSE_train   RMSE_test  R2_train   R2_test\n",
-       "base model (norm charge)   32.099531  266.750283  0.988114  0.286956\n",
-       "base model (fast charge)   55.193670   85.076788  0.920004  0.740799"
+       "                          RMSE_train   RMSE_test  R2_train   R2_test  epochs\n",
+       "base model (norm charge)   32.099531  266.750283  0.988114  0.286956     171\n",
+       "base model (fast charge)   55.193670   85.076788  0.920004  0.740799      38"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
So that the training epoch count can be added to the report.