### PR TITLE
Rename some discharge transfer models

### DIFF
--- a/discharge_model/DischargeModelTransfer.ipynb
+++ b/discharge_model/DischargeModelTransfer.ipynb
@@ -354,8 +354,8 @@
     "    index=[\n",
     "        \"base model (fast charge)\",\n",
     "        \"base model (norm charge)\",\n",
-    "        \"transfer model\",\n",
-    "        \"base model (refined)\"\n",
+    "        \"transfer model (layered)\",\n",
+    "        \"transfer model (fine-tuned only)\"\n",
     "    ],\n",
     "    columns=[\"RMSE\"]\n",
     ")"
@@ -404,7 +404,7 @@
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>base model (refined)</th>\n",
+       "      <th>transfer model (fine-tuned only)</th>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -412,11 +412,11 @@
        "</div>"
       ],
       "text/plain": [
-       "                                RMSE\n",
-       "base model (fast charge)   85.076781\n",
-       "base model (norm charge)  266.750278\n",
-       "transfer model                   NaN\n",
-       "base model (refined)             NaN"
+       "                                        RMSE\n",
+       "base model (fast charge)           85.076781\n",
+       "base model (norm charge)          266.750278\n",
+       "transfer model (layered)                 NaN\n",
+       "transfer model (fine-tuned only)         NaN"
       ]
      },
      "execution_count": 15,
@@ -761,7 +761,7 @@
     "    transfer_model(feat_test_scaled),\n",
     "    label_train,\n",
     "    label_test,\n",
-    "    \"TransferModelPrediction\"\n",
+    "    \"TransferModelLayeredPrediction\"\n",
     ")"
    ]
   },
@@ -829,11 +829,11 @@
        "      <td>131.840302</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>transfer model</th>\n",
        "      <td>133.829883</td>\n",
+       "      <th>transfer model (layered)</th>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>base model (refined)</th>\n",
+       "      <th>transfer model (fine-tuned only)</th>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -841,11 +841,11 @@
        "</div>"
       ],
       "text/plain": [
-       "                                RMSE\n",
-       "base model (fast charge)   85.076781\n",
-       "base model (norm charge)  266.750278\n",
-       "transfer model            138.527087\n",
-       "base model (refined)             NaN"
+       "                                        RMSE\n",
+       "base model (fast charge)           85.076781\n",
+       "base model (norm charge)          266.750278\n",
+       "transfer model (layered)          138.527080\n",
+       "transfer model (fine-tuned only)         NaN"
       ]
      },
      "execution_count": 25,
@@ -854,7 +854,7 @@
     }
    ],
    "source": [
-    "all_rmse.at[\"transfer model\", \"RMSE\"] = transfer_model.evaluate(\n",
+    "all_rmse.at[\"transfer model (layered)\", \"RMSE\"] = transfer_model.evaluate(\n",
     "    feat_test_scaled,\n",
     "    label_test, verbose=0) ** 0.5\n",
     "all_rmse"
@@ -865,8 +865,7 @@
    "metadata": {},
    "source": [
     "## Transfer Learning (Fine Tuning Only)\n",
-    "Just train the base model again on the 'normal charging' dataset to fine tune the weights learned from 'fast charging' and see how it's performance compares with layering method.  \n",
-    "This model is named the **refined** base model."
+    "Just train the base model again on the 'normal charging' dataset to fine tune the weights learned from 'fast charging' and see how it's performance compares with layering method."
    ]
   },
   {
@@ -977,7 +976,7 @@
     "    discharge_model_fast(feat_test_scaled),\n",
     "    label_train,\n",
     "    label_test,\n",
-    "    \"RefinedBaseModelPrediction\"\n",
+    "    \"TransferModelFineTunedPrediction\"\n",
     ")"
    ]
   },
@@ -1053,11 +1052,11 @@
        "      <td>266.75</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>transfer model</th>\n",
+       "      <th>transfer model (layered)</th>\n",
        "      <td>138.53</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>base model (refined)</th>\n",
+       "      <th>transfer model (fine-tuned only)</th>\n",
        "      <td>141.69</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1065,11 +1064,11 @@
        "</div>"
       ],
       "text/plain": [
-       "                           RMSE\n",
-       "base model (fast charge)  85.08\n",
-       "base model (norm charge) 266.75\n",
-       "transfer model           138.53\n",
-       "base model (refined)     141.69"
+       "                                   RMSE\n",
+       "base model (fast charge)          85.08\n",
+       "base model (norm charge)         266.75\n",
+       "transfer model (layered)         138.53\n",
+       "transfer model (fine-tuned only) 141.69"
       ]
      },
      "execution_count": 31,
@@ -1078,7 +1077,7 @@
     }
    ],
    "source": [
-    "all_rmse.at[\"base model (refined)\", \"RMSE\"] = discharge_model_fast.evaluate(\n",
+    "all_rmse.at[\"transfer model (fine-tuned only)\", \"RMSE\"] = discharge_model_fast.evaluate(\n",
     "    feat_test_scaled,\n",
     "    label_test, verbose=0) ** 0.5\n",
     "all_rmse"


### PR DESCRIPTION
To clarify the distinction between transfer models and base models, and highlight the difference in method used for the two discharge transfer models